### PR TITLE
Explicitly annotate non-person etymology

### DIFF
--- a/Command/GeoJSONCommand.php
+++ b/Command/GeoJSONCommand.php
@@ -395,7 +395,7 @@ class GeoJSONCommand extends AbstractCommand
             $_person = array_unique(array_column($detailsEtymology, 'person'));
             $_gender = array_unique(array_column($detailsEtymology, 'gender'));
 
-            $genderEtymology = (count($_person) === 1 && current($_person) === true) ? (count($_gender) === 1 ? current($_gender) : '+') : false;
+            $genderEtymology = (count($_person) === 1 && current($_person) === true) ? (count($_gender) === 1 ? current($_gender) : '+') : '-';
 
             if (count($detailsEtymology) === 1) {
                 $detailsEtymology = current($detailsEtymology);
@@ -433,7 +433,7 @@ class GeoJSONCommand extends AbstractCommand
                         $_person = array_unique(array_column($detailsWikidata, 'person'));
                         $_gender = array_unique(array_column($detailsWikidata, 'gender'));
 
-                        $genderWikidata = (count($_person) === 1 && current($_person) === true) ? (count($_gender) === 1 ? current($_gender) : '+') : false;
+                        $genderWikidata = (count($_person) === 1 && current($_person) === true) ? (count($_gender) === 1 ? current($_gender) : '+') : '-';
 
                         if (count($detailsWikidata) === 1) {
                             $detailsWikidata = current($detailsWikidata);


### PR DESCRIPTION
Fixes https://github.com/EqualStreetNames/equalstreetnames/issues/618. Setting gender to `'-'` instead of `null` when there is an etymology, but `person==False`, allows to render it differently from completely missing etymology (here just a subtle difference in line width).

See these screenshots of one street with person etymology, one with non-person etymology, one without etymology.

![Screenshot from 2024-03-19 10-56-54](https://github.com/EqualStreetNames/module-process/assets/5216613/d21a33ea-85ef-4c99-b282-63978b8bc903)

![Screenshot from 2024-03-19 10-57-47](https://github.com/EqualStreetNames/module-process/assets/5216613/b6d45cac-f427-4fac-9d45-e57bf14d4578)

NB: I also changed the dark mode colours for this screenshot because the current `unknown` colour is almost the same as the street colour in the map layer, not allowing to see differences in line width: https://github.com/eginhard/esn-module-website/commit/78df4891e083a89673fd787d4bed4eac957654b0