### PR TITLE
Fall back to `mul` labels

### DIFF
--- a/Wikidata/Wikidata.php
+++ b/Wikidata/Wikidata.php
@@ -42,8 +42,9 @@ class Wikidata
         $labels = [];
 
         foreach ($languages as $language) {
-            if (isset($entity->labels->{$language})) { // @phpstan-ignore-line
-                $labels[$language] = $entity->labels->{$language}; // @phpstan-ignore-line
+            $label = $entity->labels->{$language} ?? $entity->labels->mul ?? null; // @phpstan-ignore-line
+            if ($label !== null) {
+                $labels[$language] = $label;
             }
         }
 


### PR DESCRIPTION
Wikidata recently introduced “[default values for labels](https://www.wikidata.org/wiki/WD:mul)” to reduce size of items. One particular example where these are used is humans, since humans’ names are written the same in all Latin-script languages. Well, mostly. For example, [Leonardo da Vinci](https://www.wikidata.org/wiki/Q762) is called “Léonard de Vinci” in French, and because all labels that use the Italian spelling have been removed (including Dutch, English and German), now the Dutch interface falls back to the only label we extracted, saying that the namesake of Leonardo da Vincistraat is “Léonard de Vinci” rather than “Leonardo da Vinci”.

(I couldn’t find such an example in Brussels, but it’s possible that *all* labels are removed in favor of `mul`, in which case we wouldn’t extract any label, and the frontend would display `null`. That’d be even worse than showing a French label on the Dutch interface.)

This patch fixes this by falling back to the `mul` label if there is no label in the given language. This is only a fallback, so the French interface still says that the rue Léonard de Vinci is named after “Léonard de Vinci”; and it affects only labels, not descriptions, as there are no `mul` descriptions.