### PR TITLE
refactor: Fix most PHPStan errors

### DIFF
--- a/Command/Tool/CalendarCommand.php
+++ b/Command/Tool/CalendarCommand.php
@@ -76,10 +76,11 @@ class CalendarCommand extends Command
                         }
                         $time = sprintf('%02s:%02s', $parts[1], $parts[0]);
 
-                        $duplicates = array_filter($data, function ($row) use ($day, $time, $cron): bool {
-                            return $row[4]->getNextRunDate()->format('c') === $cron->getNextRunDate()->format('c');
-                            // return ($row[1] === $day && $row[3] === $time) || ($row[1] === '*' && $row[3] === $time) || ($day === '*' && $row[3] === $time);
-                        });
+                        $duplicates = array_filter(
+                            $data,
+                            fn (array $row): bool => $row[4]->getNextRunDate()->format('c') === $cron->getNextRunDate()->format('c')
+                            // fn (array $row): bool => ($row[1] === $day && $row[3] === $time) || ($row[1] === '*' && $row[3] === $time) || ($day === '*' && $row[3] === $time)
+                        );
                         $warning = count($duplicates) > 0 ? '⚠ Duplicate' : null;
 
                         $data[] = [
@@ -95,17 +96,18 @@ class CalendarCommand extends Command
                 }
             }
 
-            $nextRun = array_map(function ($row) {
-                return $row[4]->getNextRunDate()->format('c');
-            }, $data);
+            $nextRun = array_map(
+                fn (array $row): string => $row[4]->getNextRunDate()->format('c'),
+                $data
+            );
             array_multisort(
                 $nextRun,
                 SORT_ASC,
                 $data
             );
 
-            $display = array_map(function ($row) {
-                return [
+            $display = array_map(
+                fn (array $row): array => [
                     $row[0],
                     $row[1],
                     $row[2],
@@ -113,8 +115,9 @@ class CalendarCommand extends Command
                     $row[4]->getExpression(),
                     $row[4]->getNextRunDate()->format('d M Y H:i'),
                     $row[5],
-                ];
-            }, $data);
+                ],
+                $data
+            );
 
             $table = new Table($output);
             $table->setHeaders(['City', 'Day of week', 'Day of month', 'Time', 'Cron', 'Next run', '']);

--- a/Model/Details/Details.php
+++ b/Model/Details/Details.php
@@ -11,7 +11,7 @@ class Details
     public ?array $labels;
     /** @var null|array<string,LanguageValue> */
     public ?array $descriptions;
-    /** @var array<string,string> */
+    /** @var array<string,object> */
     public ?array $nicknames;
     public ?int $birth;
     public ?int $death;

--- a/Model/GeoJSON/Feature.php
+++ b/Model/GeoJSON/Feature.php
@@ -12,7 +12,7 @@ class Feature implements JsonSerializable
     public Properties $properties;
     public ?Geometry $geometry;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'type' => $this->type,

--- a/Model/GeoJSON/FeatureCollection.php
+++ b/Model/GeoJSON/FeatureCollection.php
@@ -10,7 +10,7 @@ class FeatureCollection implements JsonSerializable
   /** @var Feature[] $features */
     public array $features = [];
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
         'type' => $this->type,

--- a/Model/GeoJSON/Geometry/Geometry.php
+++ b/Model/GeoJSON/Geometry/Geometry.php
@@ -19,7 +19,7 @@ class Geometry implements JsonSerializable
         $this->coordinates = $coordinates;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'type' => $this->type,

--- a/Model/GeoJSON/Properties.php
+++ b/Model/GeoJSON/Properties.php
@@ -14,7 +14,7 @@ class Properties implements JsonSerializable
     /** @var null|Details|Details[] */
     public $details;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
         'name' => $this->name,

--- a/Wikidata/Wikidata.php
+++ b/Wikidata/Wikidata.php
@@ -92,7 +92,7 @@ class Wikidata
      * @param Entity $entity
      * @param string[] $languages
      *
-     * @return null|array<string,string>
+     * @return null|array<string,object>
      */
     public static function extractNicknames($entity, array $languages): ?array
     {
@@ -101,10 +101,12 @@ class Wikidata
         $claims = $entity->claims->P1449 ?? [];
 
         foreach ($claims as $value) {
-            $language = $value->mainsnak->datavalue->value->language; // @phpstan-ignore-line
+            /** @var \stdClass */
+            $mainValue = $value->mainsnak->datavalue->value; // @phpstan-ignore-line
+            $language = $mainValue->language;
 
             if (in_array($language, $languages, true)) {
-                $nicknames[$language] = $value->mainsnak->datavalue->value; // @phpstan-ignore-line
+                $nicknames[$language] = $mainValue;
             }
         }
 


### PR DESCRIPTION
- Add missing return types. In closures touched anyway, also add parameter types.
- Avoid capturing unused variables. They are used in the commented-out part; to make the commented-out part work out of the box if uncommented, use arrow functions (available since PHP 7.4) instead of traditional anonymous functions: arrow functions capture variables automatically, so the `use` block can simply be skipped. Use arrow functions for other touched closures as well.
- Add return types to `JsonSerializable::jsonSerialize()` overrides. The lack of return types cause deprecation warnings on PHP 8. The recommended return type of `mixed` cannot be used on PHP 7.4 (which we still support according to `composer.json`), but fortunately all classes consistently return arrays, so `array` could be added as a return type instead (which is available in PHP 7.4 as well, and which is stricter than the type stated by the interface – covariant return types are allowed since PHP 7.4).

I skipped a few errors that look real and that I don’t know how to fix.